### PR TITLE
Simplify MongoDB credential resolution in _setup_connection

### DIFF
--- a/src/etl_core/components/databases/mongodb/mongodb.py
+++ b/src/etl_core/components/databases/mongodb/mongodb.py
@@ -96,15 +96,6 @@ class MongoDBComponent(DatabaseComponent, ABC):
             return
 
         creds_map = self._get_credentials()
-        if self._credentials is None:
-            ctx = self.get_resolved_context()
-            if ctx is None:
-                self._log.debug(
-                    "%s: credentials context not resolved yet; deferring setup.",
-                    self.name,
-                )
-                return
-            self._credentials = ctx.resolve_active_credentials()
 
         self._database_name = creds_map["database"]
         self._log.debug(


### PR DESCRIPTION
### Motivation
- Avoid duplicate credential resolution by relying on the existing `_get_credentials()` helper which already resolves and stores the active credentials and credential id. 
- Remove the redundant `get_resolved_context()` / `resolve_active_credentials()` block that could lead to double-resolution or inconsistent state.

### Description
- Removed the conditional block in `MongoDBComponent._setup_connection` that called `get_resolved_context()` and `ctx.resolve_active_credentials()` and assigned `self._credentials`. 
- Now `_setup_connection` calls `creds_map = self._get_credentials()` and proceeds to set `self._database_name`, build the Mongo URI, construct `client_kwargs` via `build_mongo_client_kwargs(self._credentials)`, and initialize `MongoConnectionHandler` as before. 
- Connection setup remains idempotent and the connection handler lifecycle is unchanged.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bd80eab48328ac940a9f5a51cdca)