### PR TITLE
Allow SQL URLs without passwords

### DIFF
--- a/src/etl_core/components/databases/sql_connection_handler.py
+++ b/src/etl_core/components/databases/sql_connection_handler.py
@@ -36,12 +36,20 @@ class SQLConnectionHandler:
         port: Optional[int] = None,
         database: Optional[str] = None,
     ) -> str:
-        if not all([user, password, host, port, database]):
+        missing_required = any(
+            [
+                user in (None, ""),
+                host in (None, ""),
+                port is None,
+                database in (None, ""),
+            ]
+        )
+        if missing_required:
             raise ValueError(
-                f"{dialect} requires user, password, host, port, and database."
+                f"{dialect} requires user, host, port, and database."
             )
         safe_user = quote_plus(user)
-        safe_password = quote_plus(password)
+        safe_password = quote_plus(password or "")
         return f"{dialect}://{safe_user}:{safe_password}@{host}:{port}/{database}"
 
     @staticmethod

--- a/tests/components/databases/test_sql_connection_handler.py
+++ b/tests/components/databases/test_sql_connection_handler.py
@@ -70,8 +70,7 @@ class TestSQLConnectionHandler:
         with pytest.raises(
             ValueError,
             match=(
-                "postgresql\\+psycopg2 requires user, password, host, port, "
-                "and database"
+                "postgresql\\+psycopg2 requires user, host, port, and database"
             ),
         ):
             SQLConnectionHandler.build_url(
@@ -371,6 +370,28 @@ class TestSQLConnectionHandler:
                 port=5432,
                 database="testdb",
             )
+
+    def test_build_url_passwordless(self):
+        """Test building URL with missing or empty passwords."""
+        url_none = SQLConnectionHandler.build_url(
+            dialect="postgresql+psycopg2",
+            user="testuser",
+            password=None,
+            host="localhost",
+            port=5432,
+            database="testdb",
+        )
+        assert url_none == "postgresql+psycopg2://testuser:@localhost:5432/testdb"
+
+        url_empty = SQLConnectionHandler.build_url(
+            dialect="postgresql+psycopg2",
+            user="testuser",
+            password="",
+            host="localhost",
+            port=5432,
+            database="testdb",
+        )
+        assert url_empty == "postgresql+psycopg2://testuser:@localhost:5432/testdb"
 
     def test_build_url_special_characters(self):
         """Test URL building with special characters in credentials."""


### PR DESCRIPTION
### Motivation
- Make it possible to build SQLAlchemy DSNs for environments where a password is not provided while still enforcing required connection fields. 
- Ensure the URL includes an explicit empty password component (e.g. `user:@host`) instead of rejecting the credential set.

### Description
- Relaxed `SQLConnectionHandler.build_url` validation to require only `user`, `host`, `port`, and `database` and to allow `password` to be `None` or empty. 
- When `password` is `None` or `""`, `build_url` now URL-encodes an empty password (`quote_plus(password or "")`) so the DSN contains an empty password component (e.g. `user:@host:port/db`).
- Updated the validation error message to match the new required fields and adjusted tests accordingly.
- Added a new test `test_build_url_passwordless` in `tests/components/databases/test_sql_connection_handler.py` to cover both `password=None` and `password==""` cases.

### Testing
- Ran `pytest tests/components/databases/test_sql_connection_handler.py`; test execution failed with `ModuleNotFoundError: No module named 'etl_core'` due to the test environment import configuration, so the suite could not be fully validated here.
- Updated unit tests in `tests/components/databases/test_sql_connection_handler.py` to reflect the new error message and to include the passwordless cases (new test `test_build_url_passwordless`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983be2745648328accf174518058d62)