### PR TITLE
Clear stored secret when credentials upserted with no password

### DIFF
--- a/src/etl_core/persistence/handlers/credentials_handler.py
+++ b/src/etl_core/persistence/handlers/credentials_handler.py
@@ -78,6 +78,11 @@ class CredentialsHandler:
 
         if creds.decrypted_password:
             self.secret_store.set(self._password_key(row.id), creds.decrypted_password)
+        else:
+            try:
+                self.secret_store.delete(self._password_key(row.id))
+            except KeyError:
+                pass
 
         masked_password = _mask_secret(creds.decrypted_password)
         action = "updated" if is_update else "created"

--- a/tests/persistence/test_credentials_handler.py
+++ b/tests/persistence/test_credentials_handler.py
@@ -146,6 +146,42 @@ def test_get_by_id_when_secret_missing(handler: H.CredentialsHandler) -> None:
     assert creds.decrypted_password is None
 
 
+def test_upsert_clears_secret_when_password_removed(
+    handler: H.CredentialsHandler,
+) -> None:
+    cid = handler.upsert(
+        Credentials(
+            name="c3",
+            user="u",
+            host="h",
+            port=10,
+            database="db",
+            password="secret",
+            pool_max_size=1,
+            pool_timeout_s=1,
+        )
+    )
+
+    handler.upsert(
+        Credentials(
+            name="c3",
+            user="u",
+            host="h",
+            port=10,
+            database="db",
+            password=None,
+            pool_max_size=1,
+            pool_timeout_s=1,
+        ),
+        credentials_id=cid,
+    )
+
+    model = handler.get_by_id(cid)
+    assert model is not None
+    creds, _ = model
+    assert creds.decrypted_password is None
+
+
 def test_delete_by_id_missing_and_success_and_secret_cleanup(
     handler: H.CredentialsHandler, monkeypatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Ensure that when credentials are updated with no password the previously stored secret is removed from the secret backend to avoid stale secrets.

### Description
- Update `CredentialsHandler.upsert` to delete the secret via `self.secret_store.delete(self._password_key(row.id))` when `creds.decrypted_password` is empty or `None`, and ignore missing-key errors by catching `KeyError`.
- Add `test_upsert_clears_secret_when_password_removed` to `tests/persistence/test_credentials_handler.py` to verify that updating a credential from a password to `None` removes the secret and causes `get_by_id` to return `None` for the password.

### Testing
- Ran `pytest -q tests/persistence/test_credentials_handler.py`, which exercised the new test and existing tests in that file but the run failed due to an import error: `ModuleNotFoundError: No module named 'etl_core'` (test code and new test are present and expect package import resolution in the test environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bf0c623c83289ba6a06c3ab78519)