### PR TITLE
Add shared SQL reader and writer bases

### DIFF
--- a/src/etl_core/components/databases/mariadb/mariadb_read.py
+++ b/src/etl_core/components/databases/mariadb/mariadb_read.py
@@ -1,70 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict
-
-import dask.dataframe as dd
-import pandas as pd
-from pydantic import Field, model_validator
+from etl_core.components.databases.sql_reader_base import SQLReaderBase
 
 from etl_core.components.databases.mariadb.mariadb import MariaDBComponent
 from etl_core.components.component_registry import register_component
-from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
 from etl_core.receivers.databases.mariadb.mariadb_receiver import MariaDBReceiver
-from etl_core.components.envelopes import Out
 from etl_core.components.wiring.ports import OutPortSpec
 
 
 @register_component("read_mariadb")
-class MariaDBRead(MariaDBComponent):
+class MariaDBRead(SQLReaderBase, MariaDBComponent):
     """MariaDB reader supporting row, bulk, and bigdata modes."""
 
     OUTPUT_PORTS = (OutPortSpec(name="out", required=True, fanout="many"),)
 
     ALLOW_NO_INPUTS = True
 
-    query: str = Field(default="", description="SQL query for read operations")
-    params: Dict[str, Any] = Field(default_factory=dict, description="Query parameters")
-
-    @model_validator(mode="after")
-    def _build_objects(self) -> "MariaDBRead":
-        self._receiver = MariaDBReceiver()
-        return self
-
-    async def process_row(
-        self, payload: Any, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Stream rows one-by-one and envelope them for routing."""
-        async for row in self._receiver.read_row(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        ):
-            yield Out(port="out", payload=row)
-
-    async def process_bulk(
-        self, payload: Any, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Read full result as a pandas DataFrame and envelope it."""
-        frame: pd.DataFrame = await self._receiver.read_bulk(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=frame)
-
-    async def process_bigdata(
-        self, payload: Any, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Read result as a Dask DataFrame and envelope it."""
-        ddf: dd.DataFrame = await self._receiver.read_bigdata(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=ddf)
+    receiver_class = MariaDBReceiver

--- a/src/etl_core/components/databases/mariadb/mariadb_read.py
+++ b/src/etl_core/components/databases/mariadb/mariadb_read.py
@@ -6,6 +6,7 @@ from etl_core.components.databases.mariadb.mariadb import MariaDBComponent
 from etl_core.components.component_registry import register_component
 from etl_core.receivers.databases.mariadb.mariadb_receiver import MariaDBReceiver
 from etl_core.components.wiring.ports import OutPortSpec
+from typing import ClassVar
 
 
 @register_component("read_mariadb")
@@ -16,4 +17,4 @@ class MariaDBRead(SQLReaderBase, MariaDBComponent):
 
     ALLOW_NO_INPUTS = True
 
-    receiver_class = MariaDBReceiver
+    receiver_class: ClassVar[type] = MariaDBReceiver

--- a/src/etl_core/components/databases/mariadb/mariadb_write.py
+++ b/src/etl_core/components/databases/mariadb/mariadb_write.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, Optional  # noqa: F401
-
-import dask.dataframe as dd
-import pandas as pd
+from typing import Optional  # noqa: F401
 from pydantic import model_validator
 
 from etl_core.components.component_registry import register_component
@@ -11,15 +8,14 @@ from etl_core.components.databases.mariadb.mariadb import MariaDBComponent
 from etl_core.components.databases.database_operation_mixin import (
     DatabaseOperationMixin,
 )
+from etl_core.components.databases.sql_writer_base import SQLWriterBase
 from etl_core.components.databases.if_exists_strategy import DatabaseOperation
-from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
-from etl_core.components.envelopes import Out
 from etl_core.components.wiring.ports import InPortSpec, OutPortSpec
 from etl_core.receivers.databases.mariadb.mariadb_receiver import MariaDBReceiver
 
 
 @register_component("write_mariadb")
-class MariaDBWrite(MariaDBComponent, DatabaseOperationMixin):
+class MariaDBWrite(SQLWriterBase, MariaDBComponent, DatabaseOperationMixin):
     """
     MariaDB writer with ports + schema.
 
@@ -31,6 +27,8 @@ class MariaDBWrite(MariaDBComponent, DatabaseOperationMixin):
 
     INPUT_PORTS = (InPortSpec(name="in", required=True, fanin="many"),)
     OUTPUT_PORTS = (OutPortSpec(name="out", required=False, fanout="many"),)
+
+    receiver_class = MariaDBReceiver
 
     def _build_query(
         self, table: str, columns: list, operation: DatabaseOperation, **kwargs
@@ -79,50 +77,11 @@ class MariaDBWrite(MariaDBComponent, DatabaseOperationMixin):
     @model_validator(mode="after")
     def _build_objects(self):
         """Build MariaDB-specific objects after validation."""
-        self._receiver = MariaDBReceiver()
+        self._initialize_receiver()
         schema = self.in_port_schemas["in"]
         columns = [field.name for field in schema.fields]
         self._query = self._build_query(self.entity_name, columns, self.operation)
         return self
-
-    async def process_row(
-        self, row: Dict[str, Any], metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a single row and emit it (or receiver result) on 'out'."""
-        result = await self._receiver.write_row(
-            entity_name=self.entity_name,
-            row=row,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
-
-    async def process_bulk(
-        self, data: pd.DataFrame, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a pandas DataFrame and emit the same frame on 'out'."""
-        result = await self._receiver.write_bulk(
-            entity_name=self.entity_name,
-            frame=data,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
-
-    async def process_bigdata(
-        self, ddf: dd.DataFrame, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a Dask DataFrame and emit the same ddf on 'out'."""
-        result = await self._receiver.write_bigdata(
-            entity_name=self.entity_name,
-            frame=ddf,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
 
 
 MariaDBWrite.model_rebuild()

--- a/src/etl_core/components/databases/mariadb/mariadb_write.py
+++ b/src/etl_core/components/databases/mariadb/mariadb_write.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional  # noqa: F401
+from typing import ClassVar, Optional  # noqa: F401
 from pydantic import model_validator
 
 from etl_core.components.component_registry import register_component
@@ -28,7 +28,7 @@ class MariaDBWrite(SQLWriterBase, MariaDBComponent, DatabaseOperationMixin):
     INPUT_PORTS = (InPortSpec(name="in", required=True, fanin="many"),)
     OUTPUT_PORTS = (OutPortSpec(name="out", required=False, fanout="many"),)
 
-    receiver_class = MariaDBReceiver
+    receiver_class: ClassVar[type] = MariaDBReceiver
 
     def _build_query(
         self, table: str, columns: list, operation: DatabaseOperation, **kwargs

--- a/src/etl_core/components/databases/postgresql/postgresql_read.py
+++ b/src/etl_core/components/databases/postgresql/postgresql_read.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from etl_core.components.databases.sql_reader_base import SQLReaderBase
 
 from etl_core.components.databases.postgresql.postgresql import PostgreSQLComponent
@@ -16,4 +18,4 @@ class PostgreSQLRead(SQLReaderBase, PostgreSQLComponent):
 
     ALLOW_NO_INPUTS = True
 
-    receiver_class = PostgreSQLReceiver
+    receiver_class: ClassVar[type] = PostgreSQLReceiver

--- a/src/etl_core/components/databases/postgresql/postgresql_read.py
+++ b/src/etl_core/components/databases/postgresql/postgresql_read.py
@@ -1,74 +1,19 @@
-from typing import Any, Dict, AsyncIterator
-import pandas as pd
-import dask.dataframe as dd
-from pydantic import Field, model_validator
+from etl_core.components.databases.sql_reader_base import SQLReaderBase
 
 from etl_core.components.databases.postgresql.postgresql import PostgreSQLComponent
 from etl_core.components.component_registry import register_component
-from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
 from etl_core.receivers.databases.postgresql.postgresql_receiver import (
     PostgreSQLReceiver,
 )
-from etl_core.components.envelopes import Out
 from etl_core.components.wiring.ports import OutPortSpec
 
 
 @register_component("read_postgresql")
-class PostgreSQLRead(PostgreSQLComponent):
+class PostgreSQLRead(SQLReaderBase, PostgreSQLComponent):
     """PostgreSQL reader supporting row, bulk, and bigdata modes."""
 
     OUTPUT_PORTS = (OutPortSpec(name="out", required=True, fanout="many"),)
 
     ALLOW_NO_INPUTS = True
 
-    query: str = Field(default="", description="SQL query for read operations")
-    params: Dict[str, Any] = Field(default_factory=dict, description="Query parameters")
-
-    @model_validator(mode="after")
-    def _build_objects(self) -> "PostgreSQLRead":
-        """Build objects after validation."""
-        self._receiver = PostgreSQLReceiver()
-        return self
-
-    async def process_row(
-        self, payload: Any, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Read rows one-by-one (streaming)."""
-        async for result in self._receiver.read_row(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        ):
-            yield Out(port="out", payload=result)
-
-    async def process_bulk(
-        self,
-        payload: Any,
-        metrics: ComponentMetrics,
-    ) -> AsyncIterator[Out]:
-        """Read query results as a pandas DataFrame."""
-        frame: pd.DataFrame = await self._receiver.read_bulk(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=frame)
-
-    async def process_bigdata(
-        self,
-        payload: Any,
-        metrics: ComponentMetrics,
-    ) -> AsyncIterator[Out]:
-        """Read large query results as a Dask DataFrame."""
-        ddf: dd.DataFrame = await self._receiver.read_bigdata(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=ddf)
+    receiver_class = PostgreSQLReceiver

--- a/src/etl_core/components/databases/postgresql/postgresql_write.py
+++ b/src/etl_core/components/databases/postgresql/postgresql_write.py
@@ -1,4 +1,4 @@
-from typing import Optional  # noqa: F401
+from typing import ClassVar, Optional  # noqa: F401
 from pydantic import model_validator
 
 from etl_core.components.databases.postgresql.postgresql import PostgreSQLComponent
@@ -28,7 +28,7 @@ class PostgreSQLWrite(SQLWriterBase, PostgreSQLComponent, DatabaseOperationMixin
     INPUT_PORTS = (InPortSpec(name="in", required=True, fanin="many"),)
     OUTPUT_PORTS = (OutPortSpec(name="out", required=False, fanout="many"),)
 
-    receiver_class = PostgreSQLReceiver
+    receiver_class: ClassVar[type] = PostgreSQLReceiver
 
     def _build_query(
         self, table: str, columns: list, operation: DatabaseOperation, **kwargs

--- a/src/etl_core/components/databases/postgresql/postgresql_write.py
+++ b/src/etl_core/components/databases/postgresql/postgresql_write.py
@@ -1,24 +1,21 @@
-from typing import Any, Dict, AsyncIterator, Optional  # noqa: F401
-import pandas as pd
-import dask.dataframe as dd
+from typing import Optional  # noqa: F401
 from pydantic import model_validator
 
 from etl_core.components.databases.postgresql.postgresql import PostgreSQLComponent
 from etl_core.components.databases.database_operation_mixin import (
     DatabaseOperationMixin,
 )
+from etl_core.components.databases.sql_writer_base import SQLWriterBase
 from etl_core.components.databases.if_exists_strategy import DatabaseOperation
 from etl_core.components.component_registry import register_component
-from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
 from etl_core.receivers.databases.postgresql.postgresql_receiver import (
     PostgreSQLReceiver,
 )
-from etl_core.components.envelopes import Out
 from etl_core.components.wiring.ports import InPortSpec, OutPortSpec
 
 
 @register_component("write_postgresql")
-class PostgreSQLWrite(PostgreSQLComponent, DatabaseOperationMixin):
+class PostgreSQLWrite(SQLWriterBase, PostgreSQLComponent, DatabaseOperationMixin):
     """
     PostgreSQL writer with ports + schema.
 
@@ -30,6 +27,8 @@ class PostgreSQLWrite(PostgreSQLComponent, DatabaseOperationMixin):
 
     INPUT_PORTS = (InPortSpec(name="in", required=True, fanin="many"),)
     OUTPUT_PORTS = (OutPortSpec(name="out", required=False, fanout="many"),)
+
+    receiver_class = PostgreSQLReceiver
 
     def _build_query(
         self, table: str, columns: list, operation: DatabaseOperation, **kwargs
@@ -83,50 +82,11 @@ class PostgreSQLWrite(PostgreSQLComponent, DatabaseOperationMixin):
     @model_validator(mode="after")
     def _build_objects(self):
         """Build PostgreSQL-specific objects after validation."""
-        self._receiver = PostgreSQLReceiver()
+        self._initialize_receiver()
         schema = self.in_port_schemas["in"]
         columns = [field.name for field in schema.fields]
         self._query = self._build_query(self.entity_name, columns, self.operation)
         return self
-
-    async def process_row(
-        self, row: Dict[str, Any], metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a single row and emit it (or receiver result) on 'out'."""
-        result = await self._receiver.write_row(
-            entity_name=self.entity_name,
-            row=row,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
-
-    async def process_bulk(
-        self, data: pd.DataFrame, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a pandas DataFrame and emit the same frame on 'out'."""
-        result = await self._receiver.write_bulk(
-            entity_name=self.entity_name,
-            frame=data,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
-
-    async def process_bigdata(
-        self, ddf: dd.DataFrame, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a Dask DataFrame and emit the same ddf on 'out'."""
-        result = await self._receiver.write_bigdata(
-            entity_name=self.entity_name,
-            frame=ddf,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
 
 
 PostgreSQLWrite.model_rebuild()

--- a/src/etl_core/components/databases/sql_reader_base.py
+++ b/src/etl_core/components/databases/sql_reader_base.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, ClassVar, Dict
+
+import dask.dataframe as dd
+import pandas as pd
+from pydantic import Field, model_validator
+
+from etl_core.components.envelopes import Out
+from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
+from etl_core.receivers.databases.sql_receiver import SQLReceiver
+
+
+class SQLReaderBase:
+    """Base class for SQL readers with shared row/bulk/bigdata logic."""
+
+    receiver_class: ClassVar[type[SQLReceiver]]
+
+    query: str = Field(default="", description="SQL query for read operations")
+    params: Dict[str, Any] = Field(default_factory=dict, description="Query parameters")
+
+    @model_validator(mode="after")
+    def _build_objects(self) -> "SQLReaderBase":
+        self._receiver = self.receiver_class()
+        return self
+
+    async def process_row(
+        self, payload: Any, metrics: ComponentMetrics
+    ) -> AsyncIterator[Out]:
+        """Stream rows one-by-one and envelope them for routing."""
+        async for row in self._receiver.read_row(
+            entity_name=self.entity_name,
+            metrics=metrics,
+            query=self.query,
+            params=self.params,
+            connection_handler=self.connection_handler,
+        ):
+            yield Out(port="out", payload=row)
+
+    async def process_bulk(
+        self, payload: Any, metrics: ComponentMetrics
+    ) -> AsyncIterator[Out]:
+        """Read full result as a pandas DataFrame and envelope it."""
+        frame: pd.DataFrame = await self._receiver.read_bulk(
+            entity_name=self.entity_name,
+            metrics=metrics,
+            query=self.query,
+            params=self.params,
+            connection_handler=self.connection_handler,
+        )
+        yield Out(port="out", payload=frame)
+
+    async def process_bigdata(
+        self, payload: Any, metrics: ComponentMetrics
+    ) -> AsyncIterator[Out]:
+        """Read result as a Dask DataFrame and envelope it."""
+        ddf: dd.DataFrame = await self._receiver.read_bigdata(
+            entity_name=self.entity_name,
+            metrics=metrics,
+            query=self.query,
+            params=self.params,
+            connection_handler=self.connection_handler,
+        )
+        yield Out(port="out", payload=ddf)

--- a/src/etl_core/components/databases/sql_writer_base.py
+++ b/src/etl_core/components/databases/sql_writer_base.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, ClassVar, Dict
+
+import dask.dataframe as dd
+import pandas as pd
+
+from etl_core.components.envelopes import Out
+from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
+from etl_core.receivers.databases.sql_receiver import SQLReceiver
+
+
+class SQLWriterBase:
+    """Base class for SQL writers with shared row/bulk/bigdata logic."""
+
+    receiver_class: ClassVar[type[SQLReceiver]]
+
+    def _initialize_receiver(self) -> None:
+        self._receiver = self.receiver_class()
+
+    async def process_row(
+        self, row: Dict[str, Any], metrics: ComponentMetrics
+    ) -> AsyncIterator[Out]:
+        """Write a single row and emit it (or receiver result) on 'out'."""
+        result = await self._receiver.write_row(
+            entity_name=self.entity_name,
+            row=row,
+            metrics=metrics,
+            query=self._query,
+            connection_handler=self.connection_handler,
+        )
+        yield Out(port="out", payload=result)
+
+    async def process_bulk(
+        self, data: pd.DataFrame, metrics: ComponentMetrics
+    ) -> AsyncIterator[Out]:
+        """Write a pandas DataFrame and emit the same frame on 'out'."""
+        result = await self._receiver.write_bulk(
+            entity_name=self.entity_name,
+            frame=data,
+            metrics=metrics,
+            query=self._query,
+            connection_handler=self.connection_handler,
+        )
+        yield Out(port="out", payload=result)
+
+    async def process_bigdata(
+        self, ddf: dd.DataFrame, metrics: ComponentMetrics
+    ) -> AsyncIterator[Out]:
+        """Write a Dask DataFrame and emit the same ddf on 'out'."""
+        result = await self._receiver.write_bigdata(
+            entity_name=self.entity_name,
+            frame=ddf,
+            metrics=metrics,
+            query=self._query,
+            connection_handler=self.connection_handler,
+        )
+        yield Out(port="out", payload=result)

--- a/src/etl_core/components/databases/sqlserver/sqlserver_read.py
+++ b/src/etl_core/components/databases/sqlserver/sqlserver_read.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ClassVar
+
 from etl_core.components.databases.sql_reader_base import SQLReaderBase
 
 from etl_core.components.databases.sqlserver.sqlserver import SQLServerComponent
@@ -16,4 +18,4 @@ class SQLServerRead(SQLReaderBase, SQLServerComponent):
 
     ALLOW_NO_INPUTS = True
 
-    receiver_class = SQLServerReceiver
+    receiver_class: ClassVar[type] = SQLServerReceiver

--- a/src/etl_core/components/databases/sqlserver/sqlserver_read.py
+++ b/src/etl_core/components/databases/sqlserver/sqlserver_read.py
@@ -1,73 +1,19 @@
 from __future__ import annotations
 
-from typing import Any, Dict, AsyncIterator
-
-import pandas as pd
-import dask.dataframe as dd
-from pydantic import Field, model_validator
+from etl_core.components.databases.sql_reader_base import SQLReaderBase
 
 from etl_core.components.databases.sqlserver.sqlserver import SQLServerComponent
 from etl_core.components.component_registry import register_component
-from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
 from etl_core.receivers.databases.sqlserver.sqlserver_receiver import SQLServerReceiver
-from etl_core.components.envelopes import Out
 from etl_core.components.wiring.ports import OutPortSpec
 
 
 @register_component("read_sqlserver")
-class SQLServerRead(SQLServerComponent):
+class SQLServerRead(SQLReaderBase, SQLServerComponent):
     """SQL Server reader supporting row, bulk, and bigdata modes."""
 
     OUTPUT_PORTS = (OutPortSpec(name="out", required=True, fanout="many"),)
 
     ALLOW_NO_INPUTS = True
 
-    query: str = Field(default="", description="SQL query for read operations")
-    params: Dict[str, Any] = Field(default_factory=dict, description="Query parameters")
-
-    @model_validator(mode="after")
-    def _build_objects(self) -> "SQLServerRead":
-        """Build objects after validation."""
-        self._receiver = SQLServerReceiver()
-        return self
-
-    async def process_row(
-        self, payload: Any, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Stream rows one-by-one and envelope them for routing."""
-        async for result in self._receiver.read_row(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        ):
-            yield Out(port="out", payload=result)
-
-    async def process_bulk(
-        self,
-        payload: Any,
-        metrics: ComponentMetrics,
-    ) -> AsyncIterator[Out]:
-        """Read query results as a pandas DataFrame."""
-        frame: pd.DataFrame = await self._receiver.read_bulk(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=frame)
-
-    async def process_bigdata(
-        self, payload: Any, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Read large query results as a Dask DataFrame."""
-        ddf: dd.DataFrame = await self._receiver.read_bigdata(
-            entity_name=self.entity_name,
-            metrics=metrics,
-            query=self.query,
-            params=self.params,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=ddf)
+    receiver_class = SQLServerReceiver

--- a/src/etl_core/components/databases/sqlserver/sqlserver_write.py
+++ b/src/etl_core/components/databases/sqlserver/sqlserver_write.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional  # noqa: F401
+from typing import ClassVar, Optional  # noqa: F401
 from pydantic import model_validator
 
 from etl_core.components.databases.sqlserver.sqlserver import SQLServerComponent
@@ -28,7 +28,7 @@ class SQLServerWrite(SQLWriterBase, SQLServerComponent, DatabaseOperationMixin):
     INPUT_PORTS = (InPortSpec(name="in", required=True, fanin="many"),)
     OUTPUT_PORTS = (OutPortSpec(name="out", required=False, fanout="many"),)
 
-    receiver_class = SQLServerReceiver
+    receiver_class: ClassVar[type] = SQLServerReceiver
 
     def _build_query(
         self, table: str, columns: list, operation: DatabaseOperation, **kwargs

--- a/src/etl_core/components/databases/sqlserver/sqlserver_write.py
+++ b/src/etl_core/components/databases/sqlserver/sqlserver_write.py
@@ -1,25 +1,21 @@
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, Optional  # noqa: F401
-
-import dask.dataframe as dd
-import pandas as pd
+from typing import Optional  # noqa: F401
 from pydantic import model_validator
 
 from etl_core.components.databases.sqlserver.sqlserver import SQLServerComponent
 from etl_core.components.databases.database_operation_mixin import (
     DatabaseOperationMixin,
 )
+from etl_core.components.databases.sql_writer_base import SQLWriterBase
 from etl_core.components.databases.if_exists_strategy import DatabaseOperation
 from etl_core.components.component_registry import register_component
-from etl_core.metrics.component_metrics.component_metrics import ComponentMetrics
 from etl_core.receivers.databases.sqlserver.sqlserver_receiver import SQLServerReceiver
-from etl_core.components.envelopes import Out
 from etl_core.components.wiring.ports import InPortSpec, OutPortSpec
 
 
 @register_component("write_sqlserver")
-class SQLServerWrite(SQLServerComponent, DatabaseOperationMixin):
+class SQLServerWrite(SQLWriterBase, SQLServerComponent, DatabaseOperationMixin):
     """
     SQL Server writer with ports + schema.
 
@@ -31,6 +27,8 @@ class SQLServerWrite(SQLServerComponent, DatabaseOperationMixin):
 
     INPUT_PORTS = (InPortSpec(name="in", required=True, fanin="many"),)
     OUTPUT_PORTS = (OutPortSpec(name="out", required=False, fanout="many"),)
+
+    receiver_class = SQLServerReceiver
 
     def _build_query(
         self, table: str, columns: list, operation: DatabaseOperation, **kwargs
@@ -94,50 +92,11 @@ class SQLServerWrite(SQLServerComponent, DatabaseOperationMixin):
     @model_validator(mode="after")
     def _build_objects(self):
         """Build SQL Server-specific objects after validation."""
-        self._receiver = SQLServerReceiver()
+        self._initialize_receiver()
         schema = self.in_port_schemas["in"]
         columns = [field.name for field in schema.fields]
         self._query = self._build_query(self.entity_name, columns, self.operation)
         return self
-
-    async def process_row(
-        self, row: Dict[str, Any], metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a single row and emit it (or receiver result) on 'out'."""
-        result = await self._receiver.write_row(
-            entity_name=self.entity_name,
-            row=row,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
-
-    async def process_bulk(
-        self, data: pd.DataFrame, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a pandas DataFrame and emit the same frame on 'out'."""
-        result = await self._receiver.write_bulk(
-            entity_name=self.entity_name,
-            frame=data,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
-
-    async def process_bigdata(
-        self, ddf: dd.DataFrame, metrics: ComponentMetrics
-    ) -> AsyncIterator[Out]:
-        """Write a Dask DataFrame and emit the same ddf on 'out'."""
-        result = await self._receiver.write_bigdata(
-            entity_name=self.entity_name,
-            frame=ddf,
-            metrics=metrics,
-            query=self._query,
-            connection_handler=self.connection_handler,
-        )
-        yield Out(port="out", payload=result)
 
 
 SQLServerWrite.model_rebuild()


### PR DESCRIPTION
### Motivation
- Remove duplicated row/bulk/bigdata logic across SQL read/write components and centralize common behavior in shared base classes.
- Make per-database components smaller and inject DB-specific receiver implementations to improve maintainability and testability.
- Use existing receiver tests as behavioural references when adapting the components.

### Description
- Add `SQLReaderBase` (`src/etl_core/components/databases/sql_reader_base.py`) which provides shared `query`/`params` fields, `_build_objects` receiver initialisation, and `process_row`/`process_bulk`/`process_bigdata` implementations.
- Add `SQLWriterBase` (`src/etl_core/components/databases/sql_writer_base.py`) which provides `_initialize_receiver` and shared `process_row`/`process_bulk`/`process_bigdata` implementations.
- Update MariaDB/PostgreSQL/SQLServer read components to inherit `SQLReaderBase` and inject the specific receiver via `receiver_class = ...`.
- Update MariaDB/PostgreSQL/SQLServer write components to inherit `SQLWriterBase`, inject `receiver_class`, and call the shared `_initialize_receiver` in their build flow, removing duplicated processing methods.

### Testing
- No automated tests were executed as part of this change.
- Existing receiver unit tests in `tests/receivers/databases` were inspected and used as a reference for expected receiver behaviour but were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bf2f9f808328884570f3043f6de3)